### PR TITLE
Fix font scaling and padding in IE 11 and other changes.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -34,19 +34,21 @@
 }
 
 html, body {
+    width: 100%;
     height: 100%;
 	background: linear-gradient(90deg, #1f2932, #667d8e);
 	font-family: 'Roboto-Regular';
-    font-size: calc(9px + 1vmax);
-    /* Fix jittery scroll in chrome */
-    -webkit-transform: translate3d(0,0,0);
+    /* Allow for font scaling (also supported in IE) */
+    font-size: calc(1vw + 1vh - 1vmin + 9px);
 }
 
 #main {
     background-image: url(../svg/pattern-repeat.svg);
-	background-size: contain;
-	background-repeat: repeat-y;
+    background-repeat: repeat-y;
+    background-size: contain;
     padding: 8vw;
+    /* Fix jittery scroll in chrome */
+    -webkit-transform: translate3d(0,0,0);
 }
 
 .navbar-custom {
@@ -118,13 +120,15 @@ html, body {
 
 .section-cover {
     height: 100%;
-    padding-bottom: 6vmax;
+    /* Work-a-round for IE since it does not support vmax */
+    padding-bottom: calc(6 * (1vw + 1vh - 1vmin));
 }
 
 .section {
     height: 100%;
-    padding-top: 6vmax;
-    padding-bottom: 6vmax;
+    /* Work-a-round for IE since it does not support vmax */
+    padding-top: calc(6 * (1vw + 1vh - 1vmin));
+    padding-bottom: calc(6 * (1vw + 1vh - 1vmin));
 }
 
 .section-mobile {

--- a/index.php
+++ b/index.php
@@ -71,7 +71,7 @@ bind_textdomain_codeset("homepage", 'UTF-8');
 			</a>
 
 			<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
-				<a class="dropdown-item" href="/?lang=af"><img src="lang/af/flag.jpg"/><?php echo 'Afrikaans'; ?>Afrikaans</a>
+				<a class="dropdown-item" href="/?lang=af"><img src="lang/af/flag.jpg"/><?php echo 'Afrikaans'; ?></a>
 				<a class="dropdown-item" href="/?lang=zh_CN"><img src="lang/zh_CN/flag.jpg"/><?php echo 'Chinese Simplified'; ?></a>
 				<a class="dropdown-item" href="/?lang=zh_TW"><img src="lang/zh_TW/flag.jpg"/><?php echo 'Chinese Traditional'; ?></a>
 				<a class="dropdown-item" href="/?lang=hr"><img src="lang/hr/flag.jpg"/><?php echo 'Croatian'; ?></a>
@@ -279,7 +279,7 @@ bind_textdomain_codeset("homepage", 'UTF-8');
 				<ul>
 					<li><a href="https://www.freecadweb.org/wiki/Tutorials"><?php echo _('Tutorials'); ?></a></li>
 					<li><a href="https://www.youtube.com/results?search_query=freecad"><?php echo _('Youtube Videos'); ?></a></li>
-					<li><a href="http://area51.stackexchange.com/proposals/88434/freecad">Stack Exchange</a></li>
+					<li><a href="https://stackexchange.com/search?q=freecad">Stack Exchange</a></li>
 				</ul>
 			</div>
 
@@ -303,7 +303,7 @@ bind_textdomain_codeset("homepage", 'UTF-8');
 		</div>
 
 		<span>
-			<?php echo _('© The FreeCAD Team, 2018. Image Credits (Top to bottom): ppemawm, r-frank, epileftric, regis, rider_mortagnais, bejant'); ?>
+			<?php echo _('© The FreeCAD Team, 2018. Image Credits (Top to bottom): ppemawm, r-frank, epileftric, regis, rider_mortagnais, bejant. Homepage design by AR795.'); ?>
 		</span>
 	</footer>
 


### PR DESCRIPTION
Change log:
- Font scaling and section padding in IE 11 is fixed by replacing 'vmax' with '1vw + 1vh - 1vmin'.
- Fixed navbar position when scrolling.
- Fixed stack exchange link in the footer.
- Removed repeated 'Afrikaans' word in language selector.
- Added a small credit in the footer ;)