### PR TITLE
Fixed Broken MacOS Link on Downloads.php

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -137,7 +137,7 @@
           <div class="card-body d-block align-items-center text-center px-xl-5 py-xl-4">
             <img class="w-100 p-4" src="svg/icon-apple.svg" alt="Mac">
             <h3 class="card-title download-platform-name m-0 pb-3">Mac</h3>
-            <a class="btn btn-primary rounded-pill my-1" role="button" href="https://github.com/FreeCAD/FreeCAD/releases/download/0.18.4/FreeCAD_0.18-16146-OSX-x86_64-conda-Qt5-Py3.dmg">64-Bit</a>
+            <a class="btn btn-primary rounded-pill my-1" role="button" href="https://github.com/FreeCAD/FreeCAD/releases/download/0.19_pre/FreeCAD_0.19-22611-macOS-x86_64-conda.dmg">64-Bit</a>
           </div>
           <div class="card-footer px-xl-5 py-xl-4">
             <small class="text-muted">


### PR DESCRIPTION
The old link was pointing to the stable version for MacOS, which I guess doesn't exist? So I replaced it with a working link to the pre_19 MacOS version, which is what the version 18 download page tells mac users to use.