### PR TITLE
change riot to element

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -70,7 +70,7 @@
             <a class="dropdown-item text-dark" href="https://gitlab.com/freecad/FreeCAD">GitLab</a>
             <a class="dropdown-item text-dark" href="https://codeberg.org/FreeCAD/FreeCAD">Codeberg</a>
             <a class="dropdown-item text-dark" href="https://fosstodon.org/@FreeCAD">Mastodon</a>
-            <a class="dropdown-item text-dark" href="https://riot.im/app/#/room/#gitter_FreeCAD=2FFreeCAD:matrix.org">Matrix</a>
+            <a class="dropdown-item text-dark" href="https://app.element.io/#/room/#gitter_FreeCAD=2FFreeCAD:matrix.org">Matrix</a>
             <a class="dropdown-item text-dark" href="irc://chat.freenode.net/freecad">IRC</a>
             <a class="dropdown-item text-dark" href="https://gitter.im/FreeCAD/FreeCAD">Gitter.im</a>
             <a class="dropdown-item text-dark" href="https://www.reddit.com/r/freecad">Reddit</a>

--- a/index.php
+++ b/index.php
@@ -70,7 +70,7 @@
             <a class="dropdown-item text-dark" href="https://gitlab.com/freecad/FreeCAD">GitLab</a>
             <a class="dropdown-item text-dark" href="https://codeberg.org/FreeCAD/FreeCAD">Codeberg</a>
             <a class="dropdown-item text-dark" href="https://fosstodon.org/@FreeCAD">Mastodon</a>
-            <a class="dropdown-item text-dark" href="https://riot.im/app/#/room/#gitter_FreeCAD=2FFreeCAD:matrix.org">Matrix</a>
+            <a class="dropdown-item text-dark" href="https://app.element.io/#/room/#gitter_FreeCAD=2FFreeCAD:matrix.org">Matrix</a>
             <a class="dropdown-item text-dark" href="irc://chat.freenode.net/freecad">IRC</a>
             <a class="dropdown-item text-dark" href="https://gitter.im/FreeCAD/FreeCAD">Gitter.im</a>
             <a class="dropdown-item text-dark" href="https://www.reddit.com/r/freecad">Reddit</a>


### PR DESCRIPTION
i just stumbled upon the link to the freecad room on  matrix.org and saw that it still goes to riot.im. the new name is element.io