### PR TITLE
Added onmousehover style to home page.

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
       </div>
     </section>
 
-    <div class="d-flex justify-content-center"><img id="floating-arrow" src="svg/icon-down.svg" onClick="onClickArrow()"/></div>
+    <div class="d-flex justify-content-center"><img id="floating-arrow" src="svg/icon-down.svg" onClick="onClickArrow()" onmouseover="" style="cursor: pointer;"/></div>
 
     <a id="belowArrow"></a>
 


### PR DESCRIPTION
## Issue -
There is no change when the "floating arrow" on Home page is hovered by the user. 

## Why is this an issue?
Users may not realize that the button is clickable and miss the intended action. Changing the mouse pointer to a finger pointer on hover can enhance the user experience by providing clear and consistent feedback.

**Current behaviour-**
![image](https://user-images.githubusercontent.com/100958893/227766790-23ecd2f2-4488-4f22-ac1c-33f6a596f27b.png)


**After changes** 
![image](https://user-images.githubusercontent.com/100958893/227766765-5ba9d7d4-907e-4e17-a247-a4a2eae3bab4.png)

## What this PR does ?
Converts the "mouse pointer" to "finger pointer" for the "floating arrow" on home page.

## other possible solution 
 Remove the floating arrow button to simplify the user interface and avoid irrelevant elements on the screen.
