### PR TITLE
feat: Added GitHub Edit Links

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -41,19 +41,8 @@
     <a id="githubLink" href="#"><img class="icon-social m-3" src="svg/icon-github-light.svg" alt="GitHub" />Improve this
       page on GitHub</a>
     <?php
-      $repositoryUrls = array(
-        '/404.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/404.php',
-        '/contributor.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/contributor.php',
-        '/downloads.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/downloads.php',
-        '/features.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/features.php',
-        '/index.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/index.php',
-        '/sponsor.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/sponsor.php',
-        '/thankyou.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/thankyou.php',
-      );
-
       $currentUrl = $_SERVER['REQUEST_URI'];
-      $githubEditUrl = isset($repositoryUrls[$currentUrl]) ? $repositoryUrls[$currentUrl] : '';
-
+      $githubEditUrl = 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/' . $currentpage;
       echo '<script>document.getElementById("githubLink").setAttribute("href", "' . $githubEditUrl . '");</script>';
       ?>
     </div>

--- a/footer.php
+++ b/footer.php
@@ -36,6 +36,28 @@
       <?php echo _('and'); ?>
       <a href="<?php echo $sponsorurl; ?>"><?php echo _('other sponsors'); ?></a>
     </p>
+
+    <div class="float-sm-right">
+    <a id="githubLink" href="#"><img class="icon-social m-3" src="svg/icon-github-light.svg" alt="GitHub" />Improve this
+      page on GitHub</a>
+    <?php
+      $repositoryUrls = array(
+        '/404.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/404.php',
+        '/contributor.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/contributor.php',
+        '/downloads.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/downloads.php',
+        '/features.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/features.php',
+        '/index.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/index.php',
+        '/sponsor.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/sponsor.php',
+        '/thankyou.php' => 'https://github.com/FreeCAD/FreeCAD-Homepage/blob/master/thankyou.php',
+      );
+
+      $currentUrl = $_SERVER['REQUEST_URI'];
+      $githubEditUrl = isset($repositoryUrls[$currentUrl]) ? $repositoryUrls[$currentUrl] : '';
+
+      echo '<script>document.getElementById("githubLink").setAttribute("href", "' . $githubEditUrl . '");</script>';
+      ?>
+    </div>
+    
   </footer>
 
   <!-- Include Bootstrap JS files -->


### PR DESCRIPTION
### closes - #34 
 
###  What this PR does - 
Implemented a "Improve this page on github" link in the footer section of every webpage, directing users to their respective source files in GitHub `https://github.com/FreeCAD/FreeCAD-Homepage`. 

This feature enables users to easily fork and edit the content of webpages on GitHub.

Screenshot - 
![image](https://github.com/FreeCAD/FreeCAD-Homepage/assets/100958893/2f2620bc-ca09-48a7-930c-d1c7b522f976)
