### PR TITLE
Add header link to help for translations/localisation

### DIFF
--- a/header.php
+++ b/header.php
@@ -113,7 +113,7 @@
             <a class="dropdown-item text-dark" href="https://blog.freecad.org/jobs"><?php echo _('Jobs and funding'); ?></a>
             <a class="dropdown-item text-dark" href="https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md"><?php echo _('Contribution guidelines'); ?></a>
             <a class="dropdown-item text-dark" href="https://freecad.github.io/DevelopersHandbook/"><?php echo _('Developers handbook'); ?></a>
-            <a class="dropdown-item text-dark" href="https://wiki.freecad.org/Localisation"><?php echo _('Translations'); ?></a>
+            <a class="dropdown-item text-dark" href="<?php echo _('https://wiki.freecad.org/Localisation'); ?>"><?php echo _('Translations'); ?></a>
           </div>
         </li>
 

--- a/header.php
+++ b/header.php
@@ -113,6 +113,7 @@
             <a class="dropdown-item text-dark" href="https://blog.freecad.org/jobs"><?php echo _('Jobs and funding'); ?></a>
             <a class="dropdown-item text-dark" href="https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md"><?php echo _('Contribution guidelines'); ?></a>
             <a class="dropdown-item text-dark" href="https://freecad.github.io/DevelopersHandbook/"><?php echo _('Developers handbook'); ?></a>
+            <a class="dropdown-item text-dark" href="https://wiki.freecad.org/Localisation"><?php echo _('Translations'); ?></a>
           </div>
         </li>
 


### PR DESCRIPTION
Hi !
Here is a small update to header.php to include a link for people interested to help in translations/localisation.

The change included in this first commit is a link to the FreeCAD wiki page that has some informations about translations in FreeCAD overall (rather than a direct link to Crowdin).

Another option to discuss, proposed by @kaktusus, is to create a new page for the website, as a welcome place for new translators that could provide an in-depth description of the translation of various aspects of the FreeCAD ecosystem (GUI, docs, manual, Wiki, website, etc.), first in general and then in more detail.

What do you think ?

Note that this PR is the 2nd attempt and replaces the previous one of yesterday XD (sorry for the noise, still learning...)

![print](https://github.com/FreeCAD/FreeCAD-Homepage/assets/131592747/edd684fd-e84b-4091-8a0b-9a06185b77ba)
