### PR TITLE
Disable Gitlab checks

### DIFF
--- a/contrib/addon_github_stats.py
+++ b/contrib/addon_github_stats.py
@@ -111,6 +111,7 @@ class StatsWriter:
         return self.process_github_stats(result.text)
 
     def get_stats_for_gitlab_repo(self, repo_url: str) -> Dict[str, int]:
+        return
         gl = gitlab.Gitlab(private_token=gitlab_access_token)
         community, project = self.get_community_and_project(repo_url)
         try:


### PR DESCRIPTION
Not yet supported, and the version of python-gitlab on the server is out of date.