### PR TITLE
Make it more obvious that FreeCAD is free

### DIFF
--- a/thankyou.php
+++ b/thankyou.php
@@ -69,6 +69,24 @@
 
         <section class="row section d-flex justify-content-around">
 
+          <div class="col-lg-4">
+            <h3><?php echo _('Remember:'); ?></h3>
+          </div>
+
+          <div class="col-lg-7 text-light text-center text-lg-start px-md-4">
+
+            <p>
+            <?php echo _('FreeCAD is Free and Open Source Software, is developed
+            and maintained by volunteers, and is free to use by anybody, for any
+            purpose. There is no registering or payment needed to use it, and the
+            files you produce with it are truly yours and your only. Check the
+            <a href="https://wiki.freecad.org/License">license page</a> for more
+            details. We hope you will find FreeCAD useful!'); ?>
+            </p>
+
+            <br/><br/>
+
+          </div>
 
           <div class="col-lg-4">
             <h3><?php echo _('Support FreeCAD!'); ?></h3>


### PR DESCRIPTION
We receive recurring messages asking things like "I can't pay for FreeCAD!" or "Is FreeCAD really free?" or  "How do I pay for FreeCAD" and many more like that. I propose to make it more obvious on the FreeCAD website that FreeCAD is free.

Below are the proposed changes:

**thankyou page**

before:

![Screenshot from 2024-10-03 09-14-13](https://github.com/user-attachments/assets/a46dabfd-a29a-4830-ae4f-1e75d6262a88)

after:

![Screenshot from 2024-10-03 09-14-22](https://github.com/user-attachments/assets/059917d5-d450-4666-be21-3bcb9975ca3c)


