### PR TITLE
Removing image credits on footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -21,8 +21,7 @@
     </div>
 
     <p class="footer-credits mt-3">
-      <?php echo _('© The FreeCAD Team. Homepage image credits (top to bottom): ppemawm,
-      r-frank, epileftric, regis, rider_mortagnais, bejant.'); ?>
+      <?php echo _('© The FreeCAD Team.'); ?>
     </p>
 
     <p><?php echo _('This project is supported by:'); ?>


### PR DESCRIPTION
Since these are now moved directly to the images, there is no need for something like this to appear on every page.