### PR TITLE
Update fuse comment about appimages

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -85,7 +85,7 @@
           </div>
           <div class="card-footer px-xl-5 py-xl-4">
             <small class="text-muted">
-              <?php echo _('In some distros you might need to install fuse to be able to run the AppImage bundles.'); ?>
+              <?php echo _('In some distros you might need to install libfuse2 to be able to run the AppImage bundles.'); ?>
               <?php echo _('For other distro-specific install instructions, such as Ubuntu PPA, and other ways to install on Linux, please check out the '); ?>
               <a href="<?php echo _('https://wiki.freecad.org/Install_on_Unix'); ?>"><?php echo _('wiki'); ?></a>.
             </small>

--- a/downloads.php
+++ b/downloads.php
@@ -85,8 +85,7 @@
           </div>
           <div class="card-footer px-xl-5 py-xl-4">
             <small class="text-muted">
-              <?php echo _('In some distros you might need to install libfuse2 to be able to run the AppImage bundles.'); ?>
-              <?php echo _('For other distro-specific install instructions, such as Ubuntu PPA, and other ways to install on Linux, please check out the '); ?>
+              <?php echo _('For distro-specific install instructions such as Ubuntu PPA and other ways to install on Linux please check out the '); ?>
               <a href="<?php echo _('https://wiki.freecad.org/Install_on_Unix'); ?>"><?php echo _('wiki'); ?></a>.
             </small>
           </div>


### PR DESCRIPTION
only the libfuse2 package is required in ubuntu, the fuse package conflicts with other important packages and if you don't read carefully and accept the installation you could break your desktop environment, see https://forum.freecad.org/viewtopic.php?p=761401