### PR TITLE
Sisyphus Touch: Keeping sponsors in line

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -418,3 +418,8 @@ code {
     max-width: 50vw;
   }
 }
+@media (max-width: 662px) {
+    .sponsor {
+        width: 98%;
+    }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,6 @@ code {
 }
 @media (max-width: 662px) {
     .sponsor {
-        width: 98%;
+        width: 97%;
     }
 }


### PR DESCRIPTION
I saw a new sponsor sharing this screen in a [post](https://x.com/GenysysEngine/status/1865689842119573968) on Twitter. This is definitely an annoying thing. This is the only way it can be fixed with minimal hoeing. That's the beauty and curse of Open Source: actually, if there's something you don't like, you can change it.
Before:
![GeRCstMXYAAuRij](https://github.com/user-attachments/assets/00b34c7c-b16e-4a40-ab4d-f7d3afbc4749)
After:
![resim](https://github.com/user-attachments/assets/fa64f487-fc6f-4448-ae43-604b66ab19cc)
