### PR TITLE
Community Cleaning

### DIFF
--- a/header.php
+++ b/header.php
@@ -124,13 +124,9 @@
             <a class="dropdown-item text-dark font-weight-bold" href="https://forum.freecad.org/"><?php echo _('Forum'); ?></a>
             <a class="dropdown-item text-dark" href="https://fpa.freecad.org">The FPA</a>
             <a class="dropdown-item text-dark" href="https://github.com/FreeCAD/FreeCAD">GitHub</a>
-            <a class="dropdown-item text-dark" href="https://gitlab.com/freecad/FreeCAD">GitLab</a>
-            <a class="dropdown-item text-dark" href="https://codeberg.org/FreeCAD/FreeCAD">Codeberg</a>
             <a class="dropdown-item text-dark" href="https://fosstodon.org/@FreeCAD">Mastodon</a>
             <a class="dropdown-item text-dark" href="https://matrix.to/#/#FreeCAD_FreeCAD:gitter.im">Matrix</a>
-            <a class="dropdown-item text-dark" href="irc://irc.libera.chat/freecad">IRC</a>
             <a class="dropdown-item text-dark" href="https://web.libera.chat/#freecad">IRC via Webchat</a>
-            <a class="dropdown-item text-dark" href="https://gitter.im/FreeCAD/FreeCAD">Gitter</a>
             <a class="dropdown-item text-dark" href="https://discord.gg/w2cTKGzccC">Discord</a>
             <a class="dropdown-item text-dark" href="https://www.reddit.com/r/freecad">Reddit</a>
             <a class="dropdown-item text-dark" href="https://twitter.com/FreeCADNews">Twitter</a>


### PR DESCRIPTION
There are social links under Community. Since we have no information about whether these were used or not, I guess they were not used(I wish there was something on the site where we would know exactly what was and wasn't used.).In general, social links are not given in this way, they are given in the footer anyway, which is given in our case. Additionally, they were preventing you from accessing the calendar from the menu on mobile. This problem has now been resolved.