### PR TITLE
Telemetry: Add new orbit styles

### DIFF
--- a/posthog-event-fetcher.php
+++ b/posthog-event-fetcher.php
@@ -46,6 +46,10 @@ function filterDisplayValue($key, $value) {
                     return 'Trackball';
                 case '2':
                     return 'Free Turntable';
+                case '3':
+                    return 'Trackball Classic';
+                case '4':
+                    return 'Rounded Arcball';
                 default:
                     return 'Unknown';
             }


### PR DESCRIPTION
Mirrors the new entries in the `navigational_orbit_style` enum in https://github.com/FreeCAD/FreeCAD/pull/20535/files#diff-c63394a30dfe22f21f8ae192e0d321503c9c85f3b03c5f7bd23c589b9d330ea0R67-R69

Note, as no one seems to be using these styles with the telemetry addon, it's quite difficult to test, so I just made the changes in the GH interface without testing it.
I've doubled and triple checked the syntax and values.