### PR TITLE
Remove reference to OpenCollective tax status

### DIFF
--- a/donation.php
+++ b/donation.php
@@ -254,7 +254,7 @@ document.addEventListener('DOMContentLoaded', function() {
                   <option value="stripe" title="<?php echo _('Credit card payment via Stripe'); ?>"> <?php echo _('Credit card (Stripe)'); ?> </option>
                   <option value="paypal" title="<?php echo _('Paypal allows to donate using your Paypal account, or a credit card') ?>"> <?php echo _('Paypal'); ?> </option>
                   <option value="github" title="<?php echo _('GitHub allows you to sponsor your favorite projects using your GitHub account, and a credit card') ?>"> <?php echo _('GitHub'); ?> </option>
-                  <option value="opencollective" title="<?php echo _('OpenCollective acts as a fiscal host for open-source projects. You can donate with a credit card or bank account. OpenCollective is a 501(c)3 org and provides tax deduction in the US.') ?>"> <?php echo _('OpenCollective (501(c)3)'); ?> </option>
+                  <option value="opencollective" title="<?php echo _('OpenCollective acts as a fiscal host for open-source projects. You can donate with a credit card or bank account.') ?>"> <?php echo _('OpenCollective'); ?> </option>
                 </select>
                 <button class="btn btn-outline-light input-group-text" value="Submit" id="submit" type="button"> <?php echo _('Donate'); ?> </button>
               </div>


### PR DESCRIPTION
OpenCollective's tax deduction status is not relevant, they are not our project's Fiscal Host (that is the Open Source Collective). And *that* collective is a 501(c)(6) not-for-profit, which is quite different. We should not make any statements about the potential tax implications of donating to the project, that is going to be up to the individual and their accountant: generally speaking, these donations are *not* tax deductible for individuals.