### PR TITLE
Update minimum macOS supported version to macOS 12 Monterey for 1.1.0

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -110,7 +110,7 @@ updateLatestCategoryFromFeed(
             </div>
             <div class="card-footer px-xl-5 py-xl-4">
               <small class="text-muted">
-                <?php echo _('macOS 10.13 High Sierra is the minimum supported version. For more info on installation, please check out the '); ?>
+                <?php echo _('macOS 12 Monterey is the minimum supported version. For more info on installation, please check out the '); ?>
                 <a href="<?php echo _('https://wiki.freecad.org/Install_on_Mac'); ?>"><?php echo _('wiki'); ?></a>.
               </small>
             </div>


### PR DESCRIPTION
While looking into FreeCAD/FreeCAD#28429, I found [this discussion](https://github.com/FreeCAD/FreeCAD/discussions/25910). It seems the actual minimum supported version of macOS, now that 1.1 has been released, is actually macOS Monterey (version 12), due to the LTS version of Qt being used for 1.1 dropping support for earlier macOS versions.

I did update [the wiki's download page](https://wiki.freecad.org/Download), but I just realized that I skipped straight to the release notes, and didn't notice that the homepage also has the minimum mentioned.

So, to make it easy for you guys, here's a pull request that updates that. I did find the string "macOS 10.13 High Sierra" in translation-related files, but looking at the commit history, it seems those tend to be updated in a separate batch, so I left all of that alone.