### PR TITLE
Tighten proxy-xml access

### DIFF
--- a/blog.php
+++ b/blog.php
@@ -4,7 +4,7 @@
 ?>
 
   <script>
-    var rssFeedUrl = 'proxy-xml.php?url=https://blog.freecad.org/feed/';
+    var rssFeedUrl = 'proxy-xml.php';
 
     var categoryImages = {
         'Development Updates': 'images/Development-Updates.avif',

--- a/downloads.php
+++ b/downloads.php
@@ -52,7 +52,7 @@ function updateLatestCategoryFromFeed(xmlUrl, titleId, bodyId, buttonId, imageId
 }
 
 updateLatestCategoryFromFeed(
-  'proxy-xml.php?url=https://blog.freecad.org/category/releases/feed/',
+  'proxy-xml.php?category=releases',
   'releases-title',
   'releases-description',
   'releases-link',

--- a/events.php
+++ b/events.php
@@ -43,7 +43,7 @@ function updateLatestCategoryFromFeed(xmlUrl, titleId, bodyId, buttonId, imageId
 }
 
 updateLatestCategoryFromFeed(
-  'proxy-xml.php?url=https://blog.freecad.org/category/events/feed/',
+  'proxy-xml.php?category=events',
   'events-title',
   'events-description',
   'events-link',

--- a/proxy-xml.php
+++ b/proxy-xml.php
@@ -1,15 +1,12 @@
-﻿<?php
-if (isset($_GET['url'])) {
-    $url = $_GET['url'];
-
-    if (filter_var($url, FILTER_VALIDATE_URL)) {
-        $response = file_get_contents($url);
-
-        header('Content-Type: application/xml');
-        echo $response;
-    } else {
-        header("HTTP/1.1 400 Bad Request");
-    }
-} else {
+<?php
+$category = $_REQUEST['category'] ?? '';
+if (!in_array($category, ['', 'events', 'grants', 'releases'])) {
     header("HTTP/1.1 400 Bad Request");
+    die('Unhandled category');
 }
+
+$url = 'https://blog.freecad.org'.($category != '' ? '/category/'.$category : '').'/feed/';
+$response = file_get_contents($url);
+
+header('Content-Type: application/xml');
+echo $response;

--- a/sponsor.php
+++ b/sponsor.php
@@ -42,7 +42,7 @@ function updateLatestCategoryFromFeed(xmlUrl, titleId, bodyId, buttonId, imageId
 }
 
 updateLatestCategoryFromFeed(
-  'proxy-xml.php?url=https://blog.freecad.org/category/grants/feed/',
+  'proxy-xml.php?category=grants',
   'grants-title',
   'grants-description',
   'grants-link',


### PR DESCRIPTION
It do not make sense to have an open proxy on the website. Probably a security problem, but also makes it hard to work with as you can't immediately see what it is being used for or how many places might depend on it.