### PR TITLE
Ensure telemetry deletion only works when provided with a valid UUID

### DIFF
--- a/deletetelemetry.php
+++ b/deletetelemetry.php
@@ -1,24 +1,45 @@
 <?php
 
-    $ch = curl_init();
+    // Destructive operation: the addon issues an HTTP DELETE, so reject anything
+    // else to shut off bare GET crawls, link prefetch, and <img>-style CSRF.
+    if ($_SERVER["REQUEST_METHOD"] !== "DELETE") {
+        http_response_code(405);
+        exit;
+    }
 
-    $distinct_id = $_GET["person_id"];
+    // Require a well-formed UUIDv4 person_id so that an empty/missing/malformed
+    // value can never fall through to results[0].
+    $distinct_id = $_GET["person_id"] ?? "";
+    if (!preg_match('/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/', $distinct_id)) {
+        http_response_code(400);
+        exit;
+    }
+
     $project_id = 51229;
+    $api_key = $_SERVER["POSTHOG_API_KEY"] ?? "";
 
-    curl_setopt($ch, CURLOPT_URL, "https://eu.posthog.com/api/projects/{$project_id}/persons/?distinct_id=".urlencode($distinct_id));
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "https://eu.posthog.com/api/projects/{$project_id}/persons/?distinct_id=" . urlencode($distinct_id));
     curl_setopt($ch, CURLOPT_HTTPGET, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-Type: application/json", "Authorization: Bearer {$_SERVER["POSTHOG_API_KEY"]}"]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["Content-Type: application/json", "Authorization: Bearer {$api_key}"]);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $result = curl_exec($ch);
     $data = json_decode($result, true);
-    $uuid = $data['results'][0]['uuid'] ?? null;
     curl_close($ch);
 
+    // Require exactly one match that actually owns this distinct_id before deleting.
+    $results = $data['results'] ?? [];
+    if (count($results) !== 1 || !in_array($distinct_id, $results[0]['distinct_ids'] ?? [], true)) {
+        http_response_code(404);
+        exit;
+    }
+    $uuid = $results[0]['uuid'];
+
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, "https://eu.posthog.com/api/projects/{$project_id}/persons/{$uuid}?delete_events=true");
+    curl_setopt($ch, CURLOPT_URL, "https://eu.posthog.com/api/projects/{$project_id}/persons/" . urlencode($uuid) . "?delete_events=true");
     curl_setopt($ch, CURLOPT_HTTPGET, false);
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ["Authorization: Bearer {$_SERVER["POSTHOG_API_KEY"]}"]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["Authorization: Bearer {$api_key}"]);
     $result = curl_exec($ch);
 
     http_response_code(curl_getinfo($ch, CURLINFO_HTTP_CODE));


### PR DESCRIPTION
We received an anonymous security report today regarding a use of this script to do a mass-deletion of telemetry data. This PR removes that particular vector, and applies some more hardening. I note that this code is explicitly designed to allow anonymous deletion of telemetry data: all you need to know is the specific UUID to delete, and that is by design. UUID is a local secret, and the worst case scenario, that an attacker somehow gains access to someone's UUID and deletes any telemetry data they have provided, is a low-impact, no-data-disclosure attack that is judged an acceptable risk for the return of providing this anonymous deletion capability.